### PR TITLE
fix: release now fetches tags when flag is provided

### DIFF
--- a/cmd/uplift/release.go
+++ b/cmd/uplift/release.go
@@ -141,6 +141,7 @@ func setupReleaseContext(opts releaseOptions, out io.Writer) (*context.Context, 
 	ctx.Debug = opts.Debug
 	ctx.DryRun = opts.DryRun
 	ctx.NoPush = opts.NoPush
+	ctx.FetchTags = opts.FetchTags
 	ctx.Out = out
 	ctx.SkipChangelog = opts.SkipChangelog
 	ctx.SkipBumps = opts.SkipBumps


### PR DESCRIPTION
closes #156 