### PR TITLE
fix: include a new flag to strip existing prerelease before calculating next version

### DIFF
--- a/cmd/uplift/bump.go
+++ b/cmd/uplift/bump.go
@@ -133,6 +133,7 @@ func setupBumpContext(opts bumpOptions, out io.Writer) (*context.Context, error)
 			return nil, err
 		}
 	}
+	ctx.IgnoreExistingPrerelease = opts.IgnoreExistingPrerelease
 
 	// Handle git config. Command line flag takes precedences
 	ctx.IgnoreDetached = opts.IgnoreDetached

--- a/cmd/uplift/release.go
+++ b/cmd/uplift/release.go
@@ -183,6 +183,7 @@ func setupReleaseContext(opts releaseOptions, out io.Writer) (*context.Context, 
 			return nil, err
 		}
 	}
+	ctx.IgnoreExistingPrerelease = opts.IgnoreExistingPrerelease
 
 	// Handle git config. Command line flag takes precedences
 	ctx.IgnoreDetached = opts.IgnoreDetached

--- a/cmd/uplift/root.go
+++ b/cmd/uplift/root.go
@@ -32,13 +32,14 @@ import (
 )
 
 type globalOptions struct {
-	DryRun         bool
-	Debug          bool
-	NoPush         bool
-	Silent         bool
-	IgnoreDetached bool
-	IgnoreShallow  bool
-	ConfigDir      string
+	DryRun                   bool
+	Debug                    bool
+	NoPush                   bool
+	Silent                   bool
+	IgnoreExistingPrerelease bool
+	IgnoreDetached           bool
+	IgnoreShallow            bool
+	ConfigDir                string
 }
 type rootCommand struct {
 	Cmd  *cobra.Command
@@ -77,6 +78,7 @@ func newRootCmd(out io.Writer) *rootCommand {
 	pf.BoolVar(&rootCmd.Opts.Silent, "silent", false, "silence all logging")
 	pf.BoolVar(&rootCmd.Opts.IgnoreDetached, "ignore-detached", false, "ignore reported git detached HEAD error")
 	pf.BoolVar(&rootCmd.Opts.IgnoreShallow, "ignore-shallow", false, "ignore reported git shallow clone error")
+	pf.BoolVar(&rootCmd.Opts.IgnoreExistingPrerelease, "ignore-existing-prerelease", false, "ignore any existing prerelease when calculating next semantic version")
 
 	cmd.AddCommand(newVersionCmd(out),
 		newCompletionCmd(out),

--- a/cmd/uplift/tag.go
+++ b/cmd/uplift/tag.go
@@ -186,6 +186,7 @@ func setupTagContext(opts tagOptions, out io.Writer) (*context.Context, error) {
 			return nil, err
 		}
 	}
+	ctx.IgnoreExistingPrerelease = opts.IgnoreExistingPrerelease
 
 	// Handle git config. Command line flag takes precedences
 	ctx.IgnoreDetached = opts.IgnoreDetached

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -34,27 +34,28 @@ import (
 // Context provides a way to share common state across tasks
 type Context struct {
 	ctx.Context
-	Out              io.Writer
-	Config           config.Uplift
-	DryRun           bool
-	Debug            bool
-	CurrentVersion   semver.Version
-	NextVersion      semver.Version
-	Prerelease       string
-	Metadata         string
-	NoPrefix         bool
-	NoVersionChanged bool
-	CommitDetails    git.CommitDetails
-	FetchTags        bool
-	PrintCurrentTag  bool
-	PrintNextTag     bool
-	NoPush           bool
-	Changelog        Changelog
-	SCM              SCM
-	SkipChangelog    bool
-	SkipBumps        bool
-	IgnoreDetached   bool
-	IgnoreShallow    bool
+	Out                      io.Writer
+	Config                   config.Uplift
+	DryRun                   bool
+	Debug                    bool
+	CurrentVersion           semver.Version
+	NextVersion              semver.Version
+	Prerelease               string
+	Metadata                 string
+	IgnoreExistingPrerelease bool
+	NoPrefix                 bool
+	NoVersionChanged         bool
+	CommitDetails            git.CommitDetails
+	FetchTags                bool
+	PrintCurrentTag          bool
+	PrintNextTag             bool
+	NoPush                   bool
+	Changelog                Changelog
+	SCM                      SCM
+	SkipChangelog            bool
+	SkipBumps                bool
+	IgnoreDetached           bool
+	IgnoreShallow            bool
 }
 
 // SCM provides details about the SCM provider of a repository

--- a/internal/task/nextsemver/nextsemver_test.go
+++ b/internal/task/nextsemver/nextsemver_test.go
@@ -100,6 +100,21 @@ BREAKING CHANGE: no backwards compatibility support`,
 	}
 }
 
+func TestRun_PatchIgnorePrerelease(t *testing.T) {
+	git.InitRepo(t)
+	git.Tag("0.1.0-beta.1")
+	git.EmptyCommit(t, "fix: this is a bug fix")
+
+	ctx := &context.Context{
+		Prerelease:               "beta.1",
+		IgnoreExistingPrerelease: true,
+	}
+	err := Task{}.Run(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "0.1.1-beta.1", ctx.NextVersion.Raw)
+}
+
 func TestRun_ExistingVersionNoPrefix(t *testing.T) {
 	git.InitRepo(t)
 	git.Tag("v1.0.0")


### PR DESCRIPTION
closes #267 