### PR TITLE
fix: support the parsing of a broader range of git remote origins 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.17.0
 
 # Install tini to ensure docker waits for uplift to finish before terminating
 RUN apk add --no-cache \
-    git=2.36.2-r0 \
-    tini=0.19.0-r0 \
-    gnupg=2.2.35-r4
+    git=2.38.1-r0 \
+    tini=0.19.0-r1 \
+    gnupg=2.2.40-r0
 
 COPY uplift /usr/local/bin
 

--- a/internal/git/utils_test.go
+++ b/internal/git/utils_test.go
@@ -210,11 +210,11 @@ func TestRemote(t *testing.T) {
 		},
 		{
 			name:     "CustomGitServerSchemeWithPort",
-			cloneURL: "http://172.24.100.14:7990/owner/scheme/testing11.git",
+			cloneURL: "http://172.24.100.14:7990/owner/nested/testing11.git",
 			host:     "172.24.100.14:7990",
 			owner:    "owner",
 			repo:     "testing11",
-			path:     "owner/scheme/testing11",
+			path:     "owner/nested/testing11",
 		},
 		{
 			name:     "LocalRunningGitServer",

--- a/internal/git/utils_test.go
+++ b/internal/git/utils_test.go
@@ -208,6 +208,18 @@ func TestRemote(t *testing.T) {
 			repo:     "testing10",
 			path:     "testing10",
 		},
+		{
+			name:     "CustomGitServerSchemeWithPort",
+			cloneURL: "http://172.24.100.14:7990/owner/scheme/testing11.git",
+			host:     "172.24.100.14:7990",
+			owner:    "owner",
+			repo:     "testing11",
+			path:     "owner/scheme/testing11",
+		},
+		{
+			name:     "LocalRunningGitServer",
+			cloneURL: "http://localhost:8000/testing12.git",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -258,14 +270,6 @@ func TestRemote_NoRemoteSet(t *testing.T) {
 
 	_, err := Remote()
 	require.Error(t, err)
-}
-
-func TestRemote_MalformedURL(t *testing.T) {
-	InitRepo(t)
-	RemoteOrigin(t, "whizzbang.com/repository")
-
-	_, err := Remote()
-	require.EqualError(t, err, "malformed repository URL: whizzbang.com/repository")
 }
 
 func TestAllTags(t *testing.T) {


### PR DESCRIPTION
closes #287 