### PR TITLE
feat: add ability to filter on a prerelease when calculating the next semantic version

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -61,7 +61,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.0.0
+        uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
 

--- a/cmd/uplift/bump.go
+++ b/cmd/uplift/bump.go
@@ -155,6 +155,7 @@ func setupBumpContext(opts bumpOptions, out io.Writer) (*context.Context, error)
 		}
 	}
 	ctx.IgnoreExistingPrerelease = opts.IgnoreExistingPrerelease
+	ctx.FilterOnPrerelease = opts.FilterOnPrerelease
 
 	// Handle git config. Command line flag takes precedences
 	ctx.IgnoreDetached = opts.IgnoreDetached

--- a/cmd/uplift/release.go
+++ b/cmd/uplift/release.go
@@ -213,6 +213,7 @@ func setupReleaseContext(opts releaseOptions, out io.Writer) (*context.Context, 
 		}
 	}
 	ctx.IgnoreExistingPrerelease = opts.IgnoreExistingPrerelease
+	ctx.FilterOnPrerelease = opts.FilterOnPrerelease
 
 	// Handle git config. Command line flag takes precedences
 	ctx.IgnoreDetached = opts.IgnoreDetached

--- a/cmd/uplift/release_test.go
+++ b/cmd/uplift/release_test.go
@@ -132,7 +132,8 @@ func TestRelease_SkipChangelog(t *testing.T) {
 	err := relCmd.Cmd.Execute()
 	require.NoError(t, err)
 
-	tag := git.LatestTag()
+	suffix := ""
+	tag := git.LatestTag(suffix)
 	assert.Equal(t, "1.0.1", tag.Ref)
 
 	assert.False(t, changelogExists(t))
@@ -151,7 +152,8 @@ func TestRelease_SkipBumps(t *testing.T) {
 	err := relCmd.Cmd.Execute()
 	require.NoError(t, err)
 
-	tag := git.LatestTag()
+	suffix := ""
+	tag := git.LatestTag(suffix)
 	assert.Equal(t, "1.0.1", tag.Ref)
 
 	actual, err := os.ReadFile("test.txt")

--- a/cmd/uplift/root.go
+++ b/cmd/uplift/root.go
@@ -38,6 +38,7 @@ type globalOptions struct {
 	NoStage                  bool
 	Silent                   bool
 	IgnoreExistingPrerelease bool
+	FilterOnPrerelease       bool
 	IgnoreDetached           bool
 	IgnoreShallow            bool
 	ConfigDir                string
@@ -81,6 +82,7 @@ func newRootCmd(out io.Writer) *rootCommand {
 	pf.BoolVar(&rootCmd.Opts.IgnoreDetached, "ignore-detached", false, "ignore reported git detached HEAD error")
 	pf.BoolVar(&rootCmd.Opts.IgnoreShallow, "ignore-shallow", false, "ignore reported git shallow clone error")
 	pf.BoolVar(&rootCmd.Opts.IgnoreExistingPrerelease, "ignore-existing-prerelease", false, "ignore any existing prerelease when calculating next semantic version")
+	pf.BoolVar(&rootCmd.Opts.FilterOnPrerelease, "filter-on-prerelease", false, "filter tags that doesn't match the prerelease (requires --ignore-existing-prerelease)")
 
 	cmd.AddCommand(newVersionCmd(out),
 		newCompletionCmd(out),

--- a/cmd/uplift/tag.go
+++ b/cmd/uplift/tag.go
@@ -209,6 +209,7 @@ func setupTagContext(opts tagOptions, out io.Writer) (*context.Context, error) {
 		}
 	}
 	ctx.IgnoreExistingPrerelease = opts.IgnoreExistingPrerelease
+	ctx.FilterOnPrerelease = opts.FilterOnPrerelease
 
 	// Handle git config. Command line flag takes precedences
 	ctx.IgnoreDetached = opts.IgnoreDetached

--- a/cmd/uplift/tag.go
+++ b/cmd/uplift/tag.go
@@ -142,7 +142,7 @@ func newTagCmd(gopts *globalOptions, out io.Writer) *tagCommand {
 			// If only the current tag is to be printed, skip running a pipeline
 			// and just retrieve and print the latest tag
 			if tagCmd.Opts.PrintCurrentTag && !tagCmd.Opts.PrintNextTag {
-				tag := git.LatestTag()
+				tag := git.LatestTag(tagCmd.Opts.Prerelease)
 				fmt.Fprintf(out, tag.Ref)
 				return nil
 			}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -43,6 +43,7 @@ type Context struct {
 	Prerelease               string
 	Metadata                 string
 	IgnoreExistingPrerelease bool
+	FilterOnPrerelease       bool
 	NoPrefix                 bool
 	NoVersionChanged         bool
 	CommitDetails            git.CommitDetails

--- a/internal/git/utils.go
+++ b/internal/git/utils.go
@@ -255,13 +255,23 @@ func retrieveTags(sort []string) []TagEntry {
 }
 
 // LatestTag retrieves the latest tag within the repository
-func LatestTag() TagEntry {
+func LatestTag(suffix string) TagEntry {
 	tags := retrieveTags([]string{"--sort=-creatordate", "--sort=-v:refname"})
 	if len(tags) == 0 {
 		return TagEntry{}
 	}
+	if suffix == "" {
+		return tags[0]
+	}
+	// in case we want to consider suffix, return the first match
+	// as the slice is already sorted
+	for _, t := range tags {
+		if strings.HasSuffix(t.Ref, suffix) {
+			return t
+		}
+	}
 
-	return tags[0]
+	return TagEntry{}
 }
 
 // DescribeTag retrieves details about a specific tag

--- a/internal/git/utils_test.go
+++ b/internal/git/utils_test.go
@@ -396,7 +396,8 @@ func TestLatestTag(t *testing.T) {
 	v1, v2 := "v1.0.0", "v2.0.0"
 	TimeBasedTagSeries(t, []string{v1, v2})
 
-	tag := LatestTag()
+	suffix := ""
+	tag := LatestTag(suffix)
 	assert.Equal(t, v2, tag.Ref)
 }
 
@@ -419,14 +420,16 @@ func TestLatestTag_LargeHistory(t *testing.T) {
 		"v2",
 	})
 
-	tag := LatestTag()
+	suffix := ""
+	tag := LatestTag(suffix)
 	assert.Equal(t, "2.0.0", tag.Ref)
 }
 
 func TestLatestTag_NoTagsExist(t *testing.T) {
 	MkTmpDir(t)
 
-	tag := LatestTag()
+	suffix := ""
+	tag := LatestTag(suffix)
 	assert.Equal(t, "", tag.Ref)
 }
 
@@ -438,7 +441,8 @@ func TestLatestTag_NoSemanticTags(t *testing.T) {
 	v2 := "latest"
 	EmptyCommitAndTag(t, v2, "more work")
 
-	tag := LatestTag()
+	suffix := ""
+	tag := LatestTag(suffix)
 	assert.Equal(t, "", tag.Ref)
 }
 
@@ -448,7 +452,8 @@ func TestLatestTag_MixedTagConventions(t *testing.T) {
 	v1, v2, v3 := "v1.0.0", "2.0.0", "v3.0.0"
 	TimeBasedTagSeries(t, []string{v1, v2, v3})
 
-	tag := LatestTag()
+	suffix := ""
+	tag := LatestTag(suffix)
 	assert.Equal(t, "v3.0.0", tag.Ref)
 }
 
@@ -457,7 +462,8 @@ func TestLatestTag_CommitWithMixedTags(t *testing.T) {
 
 	EmptyCommitAndTags(t, "commit", "v1", "prod", "1.0.0")
 
-	tag := LatestTag()
+	suffix := ""
+	tag := LatestTag(suffix)
 	assert.Equal(t, "1.0.0", tag.Ref)
 }
 
@@ -467,7 +473,8 @@ func TestLatestTag_WithPrerelease(t *testing.T) {
 	t1, t2, t3, t4, t5 := "0.1.0-alpha+0001", "0.1.0-beta+0001", "0.1.0-beta+0002", "0.1.0", "0.1.1-beta+0001"
 	TimeBasedTagSeries(t, []string{t1, t2, t3, t4, t5})
 
-	tag := LatestTag()
+	suffix := ""
+	tag := LatestTag(suffix)
 
 	assert.Equal(t, "0.1.1-beta+0001", tag.Ref)
 }

--- a/internal/task/changelog/changelog_test.go
+++ b/internal/task/changelog/changelog_test.go
@@ -590,17 +590,17 @@ func TestRun_IdentifiedSCM(t *testing.T) {
 	assert.Contains(t, buf.String(), expected)
 }
 
-func TestRun_WithIncludes(t *testing.T) {
+func TestRun_WithMultipleIncludes(t *testing.T) {
 	git.InitRepo(t)
 	git.Tag("1.0.0")
-	git.EmptyCommitsAndTag(t, "1.1.0", "ci: tweak", "fix(scope1): a fix", "feat(scope1): a feature", "fix(scope2): another fix")
+	git.EmptyCommitsAndTag(t, "1.1.0", "ci: tweak", "fix(scope1): a fix", "feat(scope1): a feature", "fix(common): another fix")
 
 	var buf bytes.Buffer
 	ctx := &context.Context{
 		Out: &buf,
 		Changelog: context.Changelog{
 			DiffOnly: true,
-			Include:  []string{`^.*\(scope1\)`},
+			Include:  []string{`^.*\(scope1\)`, `^.*\(common\)`},
 		},
 		CurrentVersion: semver.Version{
 			Raw: "1.0.0",
@@ -619,8 +619,8 @@ func TestRun_WithIncludes(t *testing.T) {
 	actual := buf.String()
 	assert.Contains(t, actual, "fix(scope1): a fix")
 	assert.Contains(t, actual, "feat(scope1): a feature")
+	assert.Contains(t, actual, "fix(common): another fix")
 	assert.NotContains(t, actual, "ci: tweak")
-	assert.NotContains(t, actual, "fix(scope2): another fix")
 }
 
 func TestRun_AllWithIncludes(t *testing.T) {
@@ -655,14 +655,14 @@ func TestRun_AllWithIncludes(t *testing.T) {
 func TestRun_CombinedIncludeAndExclude(t *testing.T) {
 	git.InitRepo(t)
 	git.Tag("1.0.0")
-	git.EmptyCommitsAndTag(t, "1.1.0", "ci: tweak", "fix(scope1): a fix", "feat(scope1): a feature", "fix(scope2): another fix")
+	git.EmptyCommitsAndTag(t, "1.1.0", "ci: tweak", "fix(scope1): a fix", "feat(scope1): a feature", "feat(scope2): another feature")
 
 	var buf bytes.Buffer
 	ctx := &context.Context{
 		Out: &buf,
 		Changelog: context.Changelog{
 			DiffOnly: true,
-			Include:  []string{`^.*\(scope1\)`},
+			Include:  []string{`^.*\(scope1\)`, `^.*\(scope2\)`},
 			Exclude:  []string{`^fix`},
 		},
 		CurrentVersion: semver.Version{
@@ -681,7 +681,7 @@ func TestRun_CombinedIncludeAndExclude(t *testing.T) {
 
 	actual := buf.String()
 	assert.Contains(t, actual, "feat(scope1): a feature")
+	assert.Contains(t, actual, "feat(scope2): another feature")
 	assert.NotContains(t, actual, "ci: tweak")
 	assert.NotContains(t, actual, "fix(scope1): a fix")
-	assert.NotContains(t, actual, "fix(scope2): another fix")
 }

--- a/internal/task/gittag/gittag_test.go
+++ b/internal/task/gittag/gittag_test.go
@@ -60,7 +60,8 @@ func TestRun(t *testing.T) {
 	err := Task{}.Run(ctx)
 	require.NoError(t, err)
 
-	ltag := git.LatestTag()
+	suffix := ""
+	ltag := git.LatestTag(suffix)
 	assert.Equal(t, tag, ltag.Ref)
 }
 
@@ -79,7 +80,8 @@ func TestRun_DryRunMode(t *testing.T) {
 	err := Task{}.Run(ctx)
 	require.NoError(t, err)
 
-	ltag := git.LatestTag()
+	suffix := ""
+	ltag := git.LatestTag(suffix)
 	assert.Empty(t, ltag.Ref)
 }
 
@@ -100,7 +102,8 @@ func TestRun_NoVersionChange(t *testing.T) {
 	err := Task{}.Run(ctx)
 	require.NoError(t, err)
 
-	ltag := git.LatestTag()
+	suffix := ""
+	ltag := git.LatestTag(suffix)
 	assert.Equal(t, tag, ltag.Ref)
 }
 

--- a/internal/task/nextsemver/nextsemver.go
+++ b/internal/task/nextsemver/nextsemver.go
@@ -51,7 +51,7 @@ func (t Task) Skip(ctx *context.Context) bool {
 // Run the task
 func (t Task) Run(ctx *context.Context) error {
 	var tagSuffix string
-	if ctx.IgnoreExistingPrerelease {
+	if ctx.IgnoreExistingPrerelease && ctx.FilterOnPrerelease {
 		tagSuffix = buildTagSuffix(ctx)
 	}
 	tag := git.LatestTag(tagSuffix)

--- a/internal/task/nextsemver/nextsemver.go
+++ b/internal/task/nextsemver/nextsemver.go
@@ -23,6 +23,7 @@ SOFTWARE.
 package nextsemver
 
 import (
+	"fmt"
 	"strings"
 
 	semv "github.com/Masterminds/semver"
@@ -49,7 +50,12 @@ func (t Task) Skip(ctx *context.Context) bool {
 
 // Run the task
 func (t Task) Run(ctx *context.Context) error {
-	tag := git.LatestTag()
+	var tagSuffix string
+	if ctx.IgnoreExistingPrerelease {
+		tagSuffix = buildTagSuffix(ctx)
+	}
+	tag := git.LatestTag(tagSuffix)
+
 	if tag.Ref == "" {
 		log.Debug("repository not tagged with version")
 	} else {
@@ -125,4 +131,15 @@ func (t Task) Run(ctx *context.Context) error {
 
 	log.WithField("version", ctx.NextVersion.Raw).Info("identified next semantic version")
 	return nil
+}
+
+func buildTagSuffix(ctx *context.Context) string {
+	var suffix string
+	if ctx.Prerelease != "" {
+		suffix = fmt.Sprintf("-%s", ctx.Prerelease)
+		if ctx.Metadata != "" {
+			suffix = fmt.Sprintf("%s+%s", suffix, ctx.Metadata)
+		}
+	}
+	return suffix
 }

--- a/internal/task/nextsemver/nextsemver_test.go
+++ b/internal/task/nextsemver/nextsemver_test.go
@@ -165,11 +165,11 @@ func TestRun_IgnorePrerelease(t *testing.T) {
 		{
 			name:             "NewReleaseWithNewModule",
 			commit:           "feat: a new module",
-			curVer:           "1.0.0-moduleA",
+			curVer:           "v1.0.0-moduleA",
 			prerelease:       "moduleB",
 			ignorePrerelease: true,
 			filterPrerelease: true,
-			expected:         "0.1.0-moduleB",
+			expected:         "v0.1.0-moduleB",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/task/nextsemver/nextsemver_test.go
+++ b/internal/task/nextsemver/nextsemver_test.go
@@ -100,21 +100,6 @@ BREAKING CHANGE: no backwards compatibility support`,
 	}
 }
 
-func TestRun_PatchIgnorePrerelease(t *testing.T) {
-	git.InitRepo(t)
-	git.Tag("0.1.0-beta.1")
-	git.EmptyCommit(t, "fix: this is a bug fix")
-
-	ctx := &context.Context{
-		Prerelease:               "beta.1",
-		IgnoreExistingPrerelease: true,
-	}
-	err := Task{}.Run(ctx)
-
-	require.NoError(t, err)
-	assert.Equal(t, "0.1.1-beta.1", ctx.NextVersion.Raw)
-}
-
 func TestRun_ExistingVersionNoPrefix(t *testing.T) {
 	git.InitRepo(t)
 	git.Tag("v1.0.0")
@@ -138,6 +123,73 @@ func TestRun_NoSemanticBump(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, ctx.NoVersionChanged)
+}
+
+func TestRun_IgnorePrerelease(t *testing.T) {
+	tests := []struct {
+		name       string
+		commit     string
+		curVer     string
+		prerelease string
+		metadata   string
+		expected   string
+
+		ignorePrerelease bool
+		filterPrerelease bool
+	}{
+		{
+			name:             "PatchIncrement",
+			commit:           "fix: this is a bug fix",
+			curVer:           "0.1.0-beta.1",
+			prerelease:       "beta.1",
+			ignorePrerelease: true,
+			expected:         "0.1.1-beta.1",
+		},
+		{
+			name:             "MinorIncrementNewPrerelease",
+			commit:           "feat: a new beta",
+			curVer:           "0.1.0-beta.1",
+			prerelease:       "beta.2",
+			ignorePrerelease: true,
+			expected:         "0.2.0-beta.2",
+		},
+		{
+			name:             "PatchIncrementFilterPrerelease",
+			commit:           "fix: a new fix",
+			curVer:           "0.1.0-moduleA.1",
+			prerelease:       "moduleA.1",
+			ignorePrerelease: true,
+			filterPrerelease: true,
+			expected:         "0.1.1-moduleA.1",
+		},
+		{
+			name:             "NewReleaseWithNewModule",
+			commit:           "feat: a new module",
+			curVer:           "1.0.0-moduleA",
+			prerelease:       "moduleB",
+			ignorePrerelease: true,
+			filterPrerelease: true,
+			expected:         "0.1.0-moduleB",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			git.InitRepo(t)
+			git.Tag(tt.curVer)
+			git.EmptyCommit(t, tt.commit)
+
+			ctx := &context.Context{
+				Prerelease:               tt.prerelease,
+				Metadata:                 tt.metadata,
+				IgnoreExistingPrerelease: tt.ignorePrerelease,
+				FilterOnPrerelease:       tt.filterPrerelease,
+			}
+			err := Task{}.Run(ctx)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, ctx.NextVersion.Raw)
+		})
+	}
 }
 
 func TestRun_FirstVersion(t *testing.T) {


### PR DESCRIPTION
When enabled, uplift will filter the repository tags that match the suffix
for example, v0.1.0-beta will be bumped to v0.1.1-beta (otherwise it would bump to v0.1.0)

Solves #297 