### PR TITLE
fix: trimming all commit messages to a single line

### DIFF
--- a/internal/task/changelog/changelog.go
+++ b/internal/task/changelog/changelog.go
@@ -153,7 +153,7 @@ func (t Task) Run(ctx *context.Context) error {
 					rels[i].Changes[j].Message = msg
 				}
 				if idx := strings.Index(msg, "\n"); idx > -1 {
-					rels[i].Changes[j].Message = strings.TrimSpace(msg)
+					rels[i].Changes[j].Message = strings.TrimSpace(msg[:idx])
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes bug [recently](https://github.com/gembaadvantage/uplift/pull/416/files#diff-b590f7a84e6ca2085946cf2583f11ad0ca233c10fc4fd83f4a41c00b91dedd7aR178) introduced where trimming all commit messages to a single line got broken