### PR TITLE
docs: fix broken links within documentation

### DIFF
--- a/docs/ci/travisci.md
+++ b/docs/ci/travisci.md
@@ -1,6 +1,6 @@
 # Travis CI
 
-An example YAML file for configuring Uplift to run on [Travis CI](https://www.travis-ci.com/). Access to GitHub is managed through their dedicated [GitHub Application](https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci-using-github). Uplift requires write permissions to your repository, a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) needs to be configured with the `public_repo` permission and added to Travis CI as an [encrypted variable](https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml).
+An example YAML file for configuring Uplift to run on [Travis CI](https://www.travis-ci.com/). Access to GitHub is managed through their dedicated [GitHub Application](https://www.travis-ci.com/blog/2019-05-30-setting-up-a-ci-cd-process-on-github/). Uplift requires write permissions to your repository, a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) needs to be configured with the `public_repo` permission and added to Travis CI as an [encrypted variable](https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml).
 
 ```{ .yaml .annotate linenums="1" }
 # .travis.yml

--- a/docs/cookbook/push-options.md
+++ b/docs/cookbook/push-options.md
@@ -1,6 +1,6 @@
 # Configure GitLab pipelines with Push Options
 
-Since Git version `2.10`, a client could send arbitrary strings to a server (_remote_) using [push options](https://git-scm.com/docs/git-push#Documentation/git-push.txt--oltoptiongt) (`--push-option`). GitLab has utilized [push options](https://docs.gitlab.com/ee/user/project/push_options.html) to configure pipeline behavior since version `11.7`. This type of configuration opens up many possibilities for configuring your CI/CD workflow through uplift.
+Since Git version `2.10`, a client could send arbitrary strings to a server (_remote_) using [push options](https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionoption) (`--push-option`). GitLab has utilized [push options](https://docs.gitlab.com/ee/user/project/push_options.html) to configure pipeline behavior since version `11.7`. This type of configuration opens up many possibilities for configuring your CI/CD workflow through uplift.
 
 ## Skip Rebuilding Main Branch
 

--- a/htmltest.yml
+++ b/htmltest.yml
@@ -2,6 +2,7 @@ IgnoreURLs:
   - fonts.gstatic.com
   - https://twitter.com/GA_Uplift
   - https://docs.github.com
+  - https://git-scm.com/docs
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
 IgnoreInternalEmptyHash: true


### PR DESCRIPTION
Fix the following broken links within the documentation:

```sh
+ htmltest site -c htmltest.yml
htmltest started at 05:24:19 on site
========================================================================
cookbook/push-options/index.html
  Non-OK status: 502 --- cookbook/push-options/index.html --> https://git-scm.com/docs/git-push#Documentation/git-push.txt--oltoptiongt
ci/travisci/index.html
  Non-OK status: 404 --- ci/travisci/index.html --> https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci-using-github
========================================================================
✘✘✘ failed in 27.31[10](https://github.com/gembaadvantage/uplift/actions/runs/16245745436/job/45868417728#step:7:11)06143s
2 errors in 47 documents
```